### PR TITLE
rename application and methods to pages

### DIFF
--- a/.env-sample.json
+++ b/.env-sample.json
@@ -6,7 +6,7 @@
   "services": {
     "aws-elasticache-redis": [
       {
-        "name": "federalist-local-redis",
+        "name": "pages-local-redis",
         "credentials": {
           "uri": "<REDIS URI>"
         }
@@ -14,7 +14,7 @@
     ],
     "user-provided": [
       {
-        "name": "federalist-local-sqs-creds",
+        "name": "pages-local-sqs-creds",
         "credentials": {
           "accessKeyId": "<ACCESS KEY ID>",
           "secretAccessKey": "<SECRET ACCESS KEY>",
@@ -23,7 +23,7 @@
         }
       },
       {
-        "name": "federalist-deploy-user",
+        "name": "pages-deploy-user",
         "credentials": {
           "DEPLOY_USER_USERNAME": "<USERNAME>",
           "DEPLOY_USER_PASSWORD": "<PASSWORD>"

--- a/.env-sample.json
+++ b/.env-sample.json
@@ -23,7 +23,7 @@
         }
       },
       {
-        "name": "pages-deploy-user",
+        "name": "federalist-deploy-user",
         "credentials": {
           "DEPLOY_USER_USERNAME": "<USERNAME>",
           "DEPLOY_USER_PASSWORD": "<PASSWORD>"

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-[![Known Vulnerabilities](https://snyk.io/test/github/18F/federalist-builder/badge.svg)](https://snyk.io/test/github/18F/federalist-builder)
+[![Known Vulnerabilities](https://snyk.io/test/github/cloud-gov/pages-builder/badge.svg)](https://snyk.io/test/github/cloud-gov/pages-builder)
 
-# federalist-builder
+# pages-builder
 
-This application is used to launch build tasks for Federalist in containers on cloud.gov based on messages from an AWS SQS queue.
+This application is used to launch build tasks for cloud.gov Pages in containers on cloud.gov based on messages from a Redis queue.
 
 ## The Build Scheduler
 
-The Build Scheduler is the component of this app that recursively monitors SQS for new messages. When a new messages is received, it checks the cluster to see if enough resources are available to run a build, and if so, starts the build as a Cloud Foundry "Task".
+The Build Scheduler is the component of this app that recursively monitors Redis for new messages. When a new messages is received, it checks the cluster to see if enough resources are available to run a build, and if so, starts the build as a Cloud Foundry "Task".
 
 ## The Task Pool
 
@@ -25,9 +25,7 @@ This application uses [`yarn`](https://yarnpkg.com) to manage node dependencies.
 
 Run this with `yarn` and `yarn start`.
 
-The AWS SDK credentials should be in place, or if running on CloudFoundry, a `federalist-aws-creds` service available.
-
-The SQS message body should be JSON that takes the form of an ECS task override object:
+The Redis message body should be JSON that takes the form of an ECS task override object:
 
 ```js
 {
@@ -64,9 +62,9 @@ Additional configuration is set up through environment variables:
 
 ## Running locally
 
-`federalist-builder` is not currently designed to be run locally. Due to its tight coupling with the build process and its dependence on the Cloud Foundry environment, running it locally has the potential to create a race condition between builds running in Cloud Foundry and builds that were scheduled locally.
+`pages-builder` is not currently designed to be run locally. Due to its tight coupling with the build process and its dependence on the Cloud Foundry environment, running it locally has the potential to create a race condition between builds running in Cloud Foundry and builds that were scheduled locally.
 
-To locally test `federalist-builder`, you can run:
+To locally test `pages-builder`, you can run:
 
 ```
 yarn
@@ -75,7 +73,7 @@ yarn test
 
 ### Using docker to test locally
 
-Since `federalist-builder` has tightly coupled build process, a dependence on the Cloud Foundry platform, and third party services, running tests locally with `docker-compose` can make the development experience a bit simpler.
+Since `pages-builder` has tightly coupled build process, a dependence on the Cloud Foundry platform, and third party services, running tests locally with `docker-compose` can make the development experience a bit simpler.
 
 To build the containers run:
 `$ docker-compose build`

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -255,8 +255,8 @@ resources:
     type: cogito
     check_every: 1h
     source:
-      owner: 18F
-      repo: federalist-builder
+      owner: cloud-gov
+      repo: pages-builder
       access_token: ((gh-access-token))
       context_prefix: concourse
 

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "federalist-builder",
+  "name": "pages-builder",
   "repository": {
     "type": "git",
-    "url": "git://github.com/18f/federalist-builder.git"
+    "url": "git://github.com/cloud-gov/pages-builder.git"
   },
   "version": "0.0.0",
   "private": true,
-  "description": "Checks an SQS queue and launches Federalist builds",
+  "description": "Checks a Redis queue and launches cloud.gov Pages builds",
   "main": "app.js",
   "scripts": {
     "dev": "node -r .env app",

--- a/src/build-scheduler.js
+++ b/src/build-scheduler.js
@@ -36,7 +36,7 @@ class BuildScheduler {
   }
 
   async _attemptToStartBuild(build, queue, message) {
-    logger.verbose('Attempting to start build %s', build.federalistBuildId());
+    logger.verbose('Attempting to start build %s', build.pagesBuildId());
 
     if (await this._builderPool.canStartBuild(build)) {
       return this._startBuildAndDeleteMessage(build, queue, message);
@@ -44,7 +44,7 @@ class BuildScheduler {
 
     logger.info(
       'No resources available for build %s, waiting...',
-      build.federalistBuildId()
+      build.pagesBuildId()
     );
 
     return Promise.resolve(null);
@@ -59,7 +59,7 @@ class BuildScheduler {
           logger.verbose('Received message');
           const build = new Build(queue.extractMessageData(message));
           const { BRANCH, OWNER, REPOSITORY } = build.containerEnvironment;
-          logger.info('New build %s/%s/%s - %s', OWNER, REPOSITORY, BRANCH, build.federalistBuildId());
+          logger.info('New build %s/%s/%s - %s', OWNER, REPOSITORY, BRANCH, build.pagesBuildId());
 
           return this._attemptToStartBuild(build, queue, message);
         }
@@ -68,7 +68,7 @@ class BuildScheduler {
   }
 
   _startBuildAndDeleteMessage(build, queue, message) {
-    logger.verbose('Starting build %s', build.federalistBuildId());
+    logger.verbose('Starting build %s', build.pagesBuildId());
 
     return this._builderPool.startBuild(build)
       .then(() => queue.deleteMessage(message));

--- a/src/build.js
+++ b/src/build.js
@@ -39,7 +39,7 @@ class Build {
     this.containerSize = containerSize;
   }
 
-  federalistBuildId() {
+  pagesBuildId() {
     return this.containerEnvironment.BUILD_ID;
   }
 }

--- a/test/env.json
+++ b/test/env.json
@@ -6,7 +6,7 @@
   "services": {
     "aws-elasticache-redis": [
       {
-        "name": "federalist-test-redis",
+        "name": "pages-test-redis",
         "credentials": {
           "uri": "redis://redis:6379"
         }
@@ -14,7 +14,7 @@
     ],
     "user-provided": [
       {
-        "name": "federalist-test-sqs-creds",
+        "name": "pages-test-sqs-creds",
         "credentials": {
           "accessKeyId": "access key",
           "secretAccessKey": "secret access key",
@@ -23,7 +23,7 @@
         }
       },
       {
-        "name": "federalist-deploy-user",
+        "name": "pages-deploy-user",
         "credentials": {
           "DEPLOY_USER_USERNAME": "deploy_user",
           "DEPLOY_USER_PASSWORD": "deploy_pass"

--- a/test/env.json
+++ b/test/env.json
@@ -23,7 +23,7 @@
         }
       },
       {
-        "name": "pages-deploy-user",
+        "name": "federalist-deploy-user",
         "credentials": {
           "DEPLOY_USER_USERNAME": "deploy_user",
           "DEPLOY_USER_PASSWORD": "deploy_pass"


### PR DESCRIPTION
## Changes proposed in this pull request:
- Renames most parts of the application to `pages`
- Leaves the federalist specific pipeline alone
- Leaves the `'federalist-deploy-user'`; I wasn't sure where this user/credential was created and didn't want to break the build (also matches the name of the cf space)

## security considerations
Renaming includes some deployment keys/application names