### PR TITLE
fix: Add check for active jobs when no queued jobs are in waiting

### DIFF
--- a/src/queue-client.js
+++ b/src/queue-client.js
@@ -8,18 +8,18 @@ class QueueClient {
 
   _checkAndGrabActiveJob() {
     return this._queue.getActiveCount()
-      .then(count => {
-        if (count === 0) return undefined
+      .then((count) => {
+        if (count === 0) return undefined;
 
         return this._queue.getActive(0, 0)
-          .then(jobs => {
+          .then((jobs) => {
             const {
               id,
               data,
               timestamp,
               processedOn,
               failedReason,
-            } = jobs[0]
+            } = jobs[0];
 
             return {
               id,
@@ -27,9 +27,9 @@ class QueueClient {
               timestamp,
               processedOn,
               failedReason,
-            }
-          })
-      })
+            };
+          });
+      });
   }
 
   deleteMessage(message) {

--- a/src/queue-client.js
+++ b/src/queue-client.js
@@ -6,6 +6,32 @@ class QueueClient {
     this._queue = bullQueue;
   }
 
+  _checkAndGrabActiveJob() {
+    return this._queue.getActiveCount()
+      .then(count => {
+        if (count === 0) return undefined
+
+        return this._queue.getActive(0, 0)
+          .then(jobs => {
+            const {
+              id,
+              data,
+              timestamp,
+              processedOn,
+              failedReason,
+            } = jobs[0]
+
+            return {
+              id,
+              data,
+              timestamp,
+              processedOn,
+              failedReason,
+            }
+          })
+      })
+  }
+
   deleteMessage(message) {
     const { id } = message;
     return this._queue.getJob(id)
@@ -32,7 +58,7 @@ class QueueClient {
   receiveMessage() {
     return this._queue.getNextJob()
       .then((job) => {
-        if (!job) return undefined;
+        if (!job) return this._checkAndGrabActiveJob();
 
         const {
           id,

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,5 +1,16 @@
 const bullQueue = require('../src/bull-queue');
 
+const testAddActiveJobToQueue = (queueName, jobData, testMethod) => {
+  const testQueue = bullQueue(queueName);
+  return testQueue.addBulk(jobData)
+    .then(() => testQueue.getNextJob())
+    .then((job) => job.progress({ state: 'active' }))
+    .then(() => testMethod(testQueue))
+    .then(() => testQueue.obliterate({ force: true }))
+    .then(() => testQueue.empty())
+    .then(() => testQueue.close());
+};
+
 const testAddJobsToQueue = (queueName, jobData, testMethod) => {
   const testQueue = bullQueue(queueName);
   return testQueue.addBulk(jobData)
@@ -16,6 +27,7 @@ const testEmptyQueue = (queueName, testMethod) => {
 };
 
 module.exports = {
+  testAddActiveJobToQueue,
   testAddJobsToQueue,
   testEmptyQueue,
 };

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -4,7 +4,7 @@ const testAddActiveJobToQueue = (queueName, jobData, testMethod) => {
   const testQueue = bullQueue(queueName);
   return testQueue.addBulk(jobData)
     .then(() => testQueue.getNextJob())
-    .then((job) => job.progress({ state: 'active' }))
+    .then(job => job.progress({ state: 'active' }))
     .then(() => testMethod(testQueue))
     .then(() => testQueue.obliterate({ force: true }))
     .then(() => testQueue.empty())

--- a/test/queue-client-test.js
+++ b/test/queue-client-test.js
@@ -1,6 +1,10 @@
 const { expect } = require('chai');
 const QueueClient = require('../src/queue-client');
-const { testAddJobsToQueue, testEmptyQueue } = require('./helpers');
+const {
+  testAddActiveJobToQueue,
+  testAddJobsToQueue,
+  testEmptyQueue,
+} = require('./helpers');
 
 const jobKeys = [
   'id',
@@ -32,6 +36,23 @@ describe('QueueClient', () => {
       };
 
       return testAddJobsToQueue(queueName, jobData, testMethod);
+    });
+
+    it('should check the active jobs if there are no new jobs waiting in the queue', () => {
+      const queueName = 'active-message';
+      const jobData = [{
+        data: { test: 'data', job_id: 1 },
+      }];
+      const testMethod = (queue) => {
+        const queueClient = new QueueClient(queue);
+        return queueClient.receiveMessage()
+          .then((response) => {
+            expect(response).to.have.keys(jobKeys);
+            expect(response.data).to.deep.equal(jobData[0].data);
+          });
+      };
+
+      return testAddActiveJobToQueue(queueName, jobData, testMethod);
     });
 
     it('should receive a the FIFO message from the queue', () => {


### PR DESCRIPTION
## Changes proposed in this pull request:
- Adds check for active jobs when there are none in the waiting queue
- Jobs are moved from `waiting` to `active` if there is not enough build containers available

## security considerations
None