### PR TITLE
chore: Bump custom disk for large site builds to 7GB

### DIFF
--- a/.cloudgov/manifest.yml
+++ b/.cloudgov/manifest.yml
@@ -14,7 +14,7 @@ applications:
       TASK_DISK_GB: 4
       TASK_MAX_MEM_GB: ((task_max_mem))
       TASK_CUSTOM_MEM_GB: 8
-      TASK_CUSTOM_DISK_GB: 6
+      TASK_CUSTOM_DISK_GB: 7
       CLOUD_FOUNDRY_OAUTH_TOKEN_URL: https://login.fr.cloud.gov/oauth/token
       LOG_LEVEL: verbose
       CLOUD_GOV: "true"


### PR DESCRIPTION
This will bump update the large site build to 7GB of disk storage. The platform update has deployed via issue https://github.com/cloud-gov/product/issues/2339.

## Changes proposed in this pull request:
- Bumps the disk storage for a large site build container to 7GB

## security considerations
None
