### PR TITLE
choir: Update app to use cflinuxfs4 stack

### DIFF
--- a/.cloudgov/manifest.yml
+++ b/.cloudgov/manifest.yml
@@ -1,6 +1,7 @@
 ---
 applications:
   - name: ((product))-builder((env_postfix))
+    stack: cflinuxfs4
     routes:
       - route: ((product))-builder((env_postfix)).((domain))
     disk_quota: 512M


### PR DESCRIPTION
A part of https://github.com/cloud-gov/pages-core/issues/4054

## Changes proposed in this pull request:
- Update app manifest to use stack cflinuxfs4

## security considerations
Updates underlining linux stack the app will run on
